### PR TITLE
add encode and decode

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -20,18 +20,21 @@ npm install csv-line
 
 ```javascript
 var csvLine = require('./csv-line')
-  , toCsv1 = csvLine()
-  , toCsv2 = csvLine({ separator: '*' })
 
-console.log(toCsv1([ '"hello"', 'I am a *', 'Girfriend in a ,' ]))
-console.log(toCsv2([ 'I am a *', 'Girfriend in a ,' ]))
+var encoded = csvLine.encode([ '"hello"', 'I am a *', 'Girfriend in a ,' ])
+
+//the encoded line
+console.log(encoded)
+
+//decode it again
+console.log(csvLine.decode(decoded))
 ```
 
 ### Output
 
 ```
 """hello""",I am a *,"Girfriend in a ,"
-"I am a *"*Girfriend in a ,
+[ '"hello"', 'I am a *', 'Girfriend in a ,' ]
 ```
 
 ## Licence

--- a/test.js
+++ b/test.js
@@ -1,10 +1,40 @@
 var csvLine = require('./csv-line')
 
-require('tape')(function (t) {
-  t.equal(csvLine()([ 'foo', 'bar', undefined, 1 ]), 'foo,bar,,1')
-  t.equal(csvLine()([ '"hello"', ',beep']), '"""hello""",",beep"')
+var tape = require('tape')
+
+var examples = [
+  {
+    decoded: [ 'foo', 'bar', undefined, 1 ],
+    encoded: 'foo,bar,,1'
+  },
+  {
+    decoded: [ '"hello"', ',beep'],
+    encoded: '"""hello""",",beep"'
+  },
+  {
+    decoded: [ 1, undefined, 2 ],
+    encoded: '1,,2'
+  }
+]
+
+tape('options', function (t) {
   t.equal(csvLine({ separator: '\t'})([ 'foo', 'bar' ]), 'foo\tbar')
   t.equal(csvLine({ escapeNewlines: true })([ '\nfoo\nbar\n' ]), '\\nfoo\\nbar\\n')
   t.equal(csvLine({ escapeNewlines: true })([ 1, undefined, 2 ]), '1,,2')
   t.end()
+})
+
+tape('encode', function (t) {
+  examples.forEach(function (ex) {
+    t.equal(csvLine.encode(ex.decoded), ex.encoded)
+  })
+  t.end()
+})
+
+tape('decode', function (t) {
+  examples.forEach(function (ex) {
+    t.deepEqual(csvLine.decode(ex.encoded), ex.decoded)
+  })
+  t.end()
+
 })


### PR DESCRIPTION
this PR adds a `decode` method to this module.
it's backwards compatible, and correctly parses quotes etc.

I also updated the documentation to show the encode and decode.

I also took the liberty to remove the option to change the separator,
I figure this is confusing and most users wont actually want to do that.

Also, decode doesn't support that yet -
